### PR TITLE
Fix for null mining tiers causing NPEs

### DIFF
--- a/src/main/java/dev/lukebemish/excavatedvariants/impl/MiningLevelTagHolder.java
+++ b/src/main/java/dev/lukebemish/excavatedvariants/impl/MiningLevelTagHolder.java
@@ -32,7 +32,21 @@ public class MiningLevelTagHolder implements TagSupplier {
     }
 
     private Set<ResourceLocation> getMiningLevels() {
-        return KnownTiers.KNOWN_TIERS.keySet().stream().map(TagKey::location).map(rl -> rl.withPrefix("block/")).collect(Collectors.toSet());
+        return KnownTiers.KNOWN_TIERS.keySet().stream()
+                .filter(key -> {
+                    if (key == null) {
+                        ExcavatedVariants.LOGGER.error("Found null tier TagKey in KNOWN_TIERS");
+                        return false;
+                    }
+                    if (key.location() == null) {
+                        ExcavatedVariants.LOGGER.error("Found TagKey with null location in KNOWN_TIERS: {}", key);
+                        return false;
+                    }
+                    return true;
+                })
+                .map(TagKey::location)
+                .map(rl -> rl.withPrefix("block/"))
+                .collect(Collectors.toSet());
     }
 
     @Override


### PR DESCRIPTION
Prevent NullPointerExceptions from other mods (e.g., Simply Swords) adding Tiers without valid mining tags. Adds validation and logging for null TagKeys in getMiningLevels() and skips invalid entries. Currently a null tier causes a NPE making all ore variants have no valid mining tiers.

Fixes: #255 #269 