### PR TITLE
Fixing Galosphere 1.5.0 compat on 1.20.1

### DIFF
--- a/Common/src/main/resources/defaultresources/excavated_variants/excavated_variants/variants/galosphere.json5
+++ b/Common/src/main/resources/defaultresources/excavated_variants/excavated_variants/variants/galosphere.json5
@@ -41,7 +41,7 @@
     {
       id: 'palladium_ore',
       lang: {
-        en_us: 'palladium Ore',
+        en_us: 'Palladium Ore',
       },
       block_id: [
         'galosphere:palladium_ore',

--- a/Common/src/main/resources/defaultresources/excavated_variants/excavated_variants/variants/galosphere.json5
+++ b/Common/src/main/resources/defaultresources/excavated_variants/excavated_variants/variants/galosphere.json5
@@ -39,13 +39,13 @@
   ],
   provided_ores: [
     {
-      id: 'silver_ore',
+      id: 'palladium_ore',
       lang: {
-        en_us: 'Silver Ore',
+        en_us: 'palladium Ore',
       },
       block_id: [
-        'galosphere:silver_ore',
-        'galosphere:deepslate_silver_ore',
+        'galosphere:palladium_ore',
+        'galosphere:deepslate_palladium_ore',
       ],
       types: [
         'stone',


### PR DESCRIPTION
Galosphere changed silver to palladium in latest update and the tags are now broken because the block ids don't exist. I think this fixes it